### PR TITLE
add js-server submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ tmp/
 .envrc
 resources/mathlib4-prompts.jsonl
 resources/mathlib4-descs.jsonl
+
+# remove node_modules in js-server
+./js-server/node_modules/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,10 @@
 [submodule "lean3-statement-translation-tool"]
 	path = lean3-statement-translation-tool
 	url = https://github.com/0art0/lean3-statement-translation-tool
+[submodule "dumb-server"]
+	path = js-server
+	url = https://codeberg.org/shubhamkumar13/dumb-server.git
+[submodule "js-server"]
+	branch = alpha/v1
+	path = js-server
+	url = git@github.com:shubhamkumar13/js-server-leanaide.git


### PR DESCRIPTION
Since I have added the git branch as a submodule. One needs to do the following steps to check if the `js-server` is pulled in and branch `alpha/v1` is checked-in after cloning the repo

1.  checkout the current PR branch 
    ```
    git checkout js-server/alpha-v1
    ```
2.  sync and update for  `alpha/v1` branch on [my repo](https://codeberg.org/shubhamkumar13/dumb-server/src/branch/alpha/v1)  
    ```
    git submodule sync && git submodule update --init
    ```
3. `cd js-server` and check if the branch is `main` or `alpha/v1`. **If it is main** - `git checkout alpha/v1`
4. The readme on the `alpha/v1` branch has instructions for linux

After following the readme, if the per-requisites and rabbitmq queue is up and running. Please run the either of the following command.

```bash
mise exec bun -- bun run index.ts
```
OR
```bash
bun run index.ts
```
