### PR TITLE
added apply_any? tactic

### DIFF
--- a/LeanAideCore/LeanAideCore/RunTactics.lean
+++ b/LeanAideCore/LeanAideCore/RunTactics.lean
@@ -513,17 +513,13 @@ partial def extractIntros (goal: MVarId) (maxDepth : Nat) (accum: List Name := [
 
 syntax (name := applyAnyTac) "apply_any?" : tactic
 
-@[tactic applyAnyTac] def applyAnyTacWrapper: Tactic := fun stx => do
+@[tactic applyAnyTac] def applyAnyTacImpl: Tactic := fun stx => do
   let goal ← getMainGoal
   goal.withContext do
 
     let lctx ← getLCtx
-    let visibleDecls := lctx.decls.toList.filterMap id |>.filter
-      (fun d => !d.isImplementationDetail)
 
-    let mut foundTac? : Option (TSyntax `tactic) := none
-
-    for decl in visibleDecls do
+    for decl in lctx do
       let isAccessible := !decl.userName.hasMacroScopes && !decl.userName.isInternal
 
       let tac ← if isAccessible then
@@ -535,26 +531,21 @@ syntax (name := applyAnyTac) "apply_any?" : tactic
 
       let state ← saveState
 
-      let success ← try
-        evalTactic tac
-        pure true
-      catch _ =>
-        pure false
-
-      state.restore
-      if success then
-        foundTac? := some tac
-
-        break
-      else
+      try
+        let (mvars, _) ← Elab.runTactic goal tac
         state.restore
+        if mvars.isEmpty then
+          TryThis.addSuggestion stx tac
+          return
+        else
+          continue
+      catch _ =>
+          state.restore
+          continue
+    traceAide `leanaide.interpreter.debug s!"apply_any? tactic did not find any applicable hypothesis."
+    throwError "apply_any? could not close the goal using hypotheses"
 
-    match foundTac? with
-    | some tac =>
-      TryThis.addSuggestion stx tac
-    | none =>
-      traceAide `leanaide.interpreter.debug s!"apply_any? tactic did not find any applicable hypothesis."
-      throwError "apply_any? failed: no local hypotheses could close the goal."
+
 
 
 -- open Lean Tactic Elab

--- a/LeanAideCore/LeanAideCore/RunTactics.lean
+++ b/LeanAideCore/LeanAideCore/RunTactics.lean
@@ -510,6 +510,53 @@ partial def extractIntros (goal: MVarId) (maxDepth : Nat) (accum: List Name := [
   | _, _ => do
     return (goal, accum)
 
+
+syntax (name := applyAnyTac) "apply_any?" : tactic
+
+@[tactic applyAnyTac] def applyAnyTacWrapper: Tactic := fun stx => do
+  let goal ← getMainGoal
+  goal.withContext do
+
+    let lctx ← getLCtx
+    let visibleDecls := lctx.decls.toList.filterMap id |>.filter
+      (fun d => !d.isImplementationDetail)
+
+    let mut foundTac? : Option (TSyntax `tactic) := none
+
+    for decl in visibleDecls do
+      let isAccessible := !decl.userName.hasMacroScopes && !decl.userName.isInternal
+
+      let tac ← if isAccessible then
+        let id := mkIdent decl.userName
+        `(tactic| apply $id)
+      else
+        let typeStx ← delabDetailed decl.type
+        `(tactic| apply ‹$typeStx›)
+
+      let state ← saveState
+
+      let success ← try
+        evalTactic tac
+        pure true
+      catch _ =>
+        pure false
+
+      state.restore
+      if success then
+        foundTac? := some tac
+
+        break
+      else
+        state.restore
+
+    match foundTac? with
+    | some tac =>
+      TryThis.addSuggestion stx tac
+    | none =>
+      traceAide `leanaide.interpreter.debug s!"apply_any? tactic did not find any applicable hypothesis."
+      throwError "apply_any? failed: no local hypotheses could close the goal."
+
+
 -- open Lean Tactic Elab
 -- def getPremiseNames (goalType: Expr)
 --     (selector: Option Selector := none)

--- a/LeanAideTest/RunTactics.lean
+++ b/LeanAideTest/RunTactics.lean
@@ -180,9 +180,11 @@ trace: [leanaide.frontend.debug] Try this:
 #guard_msgs in
 #findTryThis? ∀(n : Nat), n + 1 ≤ 3 using try_this (intro n; apply Nat.le_of_succ_le_succ) then (simp?; try(simp?); sorry)
 
+/-
 example : ∀ (n : ℕ), n + (1 : ℕ) ≤ (3 : ℕ) := by
   try_this(intro n; apply Nat.le_of_succ_le_succ)then(simp?; sorry)
 
+-/
 
 /--
 info: Try this:
@@ -195,7 +197,7 @@ Note: This linter can be disabled with `set_option linter.unusedVariables false`
 #guard_msgs in
 example (P Q : Prop) (hp : P) (hq : Q) : Q := by
   apply_any?
-  exact hq
+  apply hq
 
 /--
 info: Try this:
@@ -217,3 +219,8 @@ theorem hidden_hypotheses_example (P Q : Prop) (h : P ∧ Q) : P := by
   -- Instead, we can use the French quote syntax we discussed earlier
   -- to extract the inaccessible hypothesis by its type:
   exact ‹P›
+
+/-- error: apply_any? could not close the goal using hypotheses -/
+#guard_msgs in
+example (P Q : Prop) (h : P ∧ Q) : P := by
+  apply_any?

--- a/LeanAideTest/RunTactics.lean
+++ b/LeanAideTest/RunTactics.lean
@@ -182,3 +182,38 @@ trace: [leanaide.frontend.debug] Try this:
 
 example : ∀ (n : ℕ), n + (1 : ℕ) ≤ (3 : ℕ) := by
   try_this(intro n; apply Nat.le_of_succ_le_succ)then(simp?; sorry)
+
+
+/--
+info: Try this:
+  [apply] apply hq
+---
+warning: unused variable `hp`
+
+Note: This linter can be disabled with `set_option linter.unusedVariables false`
+-/
+#guard_msgs in
+example (P Q : Prop) (hp : P) (hq : Q) : Q := by
+  apply_any?
+  exact hq
+
+/--
+info: Try this:
+  [apply] apply ‹P›
+-/
+#guard_msgs in
+theorem hidden_hypotheses_example (P Q : Prop) (h : P ∧ Q) : P := by
+  -- We use `cases` to split the conjunction (AND) into its two parts.
+  -- However, we didn't tell Lean what to name the two new hypotheses!
+  cases h
+  apply_any?
+  -- At this exact line, if you look at the Lean infoview,
+  -- your proof state looks like this:
+  -- P Q : Prop
+  -- ✝¹ : P
+  -- ✝ : Q
+  -- ⊢ P
+  -- Because they have daggers, we cannot type `exact ✝¹`.
+  -- Instead, we can use the French quote syntax we discussed earlier
+  -- to extract the inaccessible hypothesis by its type:
+  exact ‹P›


### PR DESCRIPTION
This pertains to the second item in Issue #171.

We extract the type of the hypotheses with inaccessible names and do `apply <$type>`