### PR TITLE
Refined automation

### DIFF
--- a/LeanAide/Codegen.lean
+++ b/LeanAide/Codegen.lean
@@ -36,7 +36,7 @@ end Codegen
 
 set_option linter.unreachableTactic false in
 set_option linter.unusedTactic false in
-#add_auto_tactics [hammer {aesopPremises := 5, autoPremises := 0}, try_this (constructor) then (grind?)]
+#add_auto_tactics (level:= 3) [hammer {aesopPremises := 5, autoPremises := 0}, try_this (constructor) then (grind?)]
 
 
 -- #eval getAutoTactics
@@ -85,7 +85,6 @@ example : True := by
     use 3
   let ⟨n, h⟩ := egExists
   simp
-
 
 
 

--- a/LeanAideCore/LeanAideCore/CodegenCore.lean
+++ b/LeanAideCore/LeanAideCore/CodegenCore.lean
@@ -28,7 +28,7 @@ instance : ToString SyntaxNodeKinds where
 
 namespace Codegen
 
-#add_auto_tactics [llm?]
+#add_auto_tactics (level:=3) [llm?]
 
 #logIO leanaide.codegen.info
 #logFile leanaide.codegen.info
@@ -299,16 +299,8 @@ def findTactics? (goal :  MVarId):
   traceAide `leanaide.codegen.info "Trying automation tactics"
   let localNames  ← Translate.defsNames
   traceAide `leanaide.codegen.info s!"previous definitions/theorems names: {localNames}"
-  -- TODO-TacticOrderLazy: these suggestion tactics are constructed eagerly
-  -- before the ordered tactic search.  Stage this so cheaper automation can
-  -- succeed without paying for expensive failed `simp?`/`grind?` suggestion
-  -- search.
-  let grindWs ← grindWithSuggestions
-  let simpWs ← simpWithSuggestions goal localNames
-  runTacticsAndFindTryThis? goal ([← `(tacticSeq|  simp?), ← `(tacticSeq | grind?),
-  -- ← `(tacticSeq| try?),
-  grindWs, simpWs, ← `(tacticSeq| try simp; exact?)] ++ (← getAutoTactics).toList)
-    (← cmdPreludeBlob).hash (strict := true)
+  let autoTacs ← automationTactics goal localNames (← getAutomationLevel)
+  runTacticsAndFindTryThis? goal autoTacs (← cmdPreludeBlob).hash
 
 /- Find tactics using automation. Defaults to `repeat (sorry)` if no tactics are found. Use
 `findTactics?` to keep errors explicit.

--- a/LeanAideCore/LeanAideCore/ConfigExts.lean
+++ b/LeanAideCore/LeanAideCore/ConfigExts.lean
@@ -1,5 +1,6 @@
 import Lean
 
+
 open Lean Meta Elab Term
 
 namespace LeanAide
@@ -18,7 +19,6 @@ def levelNames :=
   [`u, `v, `u_1, `u_2, `u_3, `u_4, `u_5, `u_6, `u_7, `u_8, `u_9, `u_10, `u_11, `u₁, `u₂, `v₁, `v₂, `uι, `W₁, `W₂, `w₁, `w₂, `u', `v', `uu, `w, `w', `wE, `uE, `x]
 
 def univLine : String := levelNames.foldl (fun s u => s!"{s} {u}") "universe"
-
 
 def topCodeData : TopCodeData :=
   { imports := ["import Mathlib"]
@@ -86,19 +86,56 @@ initialize registerBuiltinAttribute {
 
 open Parser Tactic
 
-initialize extraAutoTacticsExt :
-    SimpleScopedEnvExtension (TSyntax ``tacticSeq) (Array (TSyntax ``tacticSeq)) ←
+initialize staticAutoTacticsExt :
+    SimpleScopedEnvExtension (Nat × TSyntax ``tacticSeq) (Array (Nat × TSyntax ``tacticSeq)) ←
   registerSimpleScopedEnvExtension {
     addEntry := fun m n =>
         m.push n
     initial := #[] -- empty by default
   }
 
-elab "#add_auto_tactics" "[" tacs:tacticSeq,* "]" : command => do
-  for tac in tacs.getElems do
-    extraAutoTacticsExt.add tac
+syntax "#add_auto_tactics" ("(level:=" num")")? "[" tacticSeq,* "]" : command
 
-def getAutoTactics : MetaM (Array (TSyntax ``tacticSeq)) := do
-  return extraAutoTacticsExt.getState (← getEnv)
+elab_rules : command
+  | `(command| #add_auto_tactics (level:=$n:num) [ $tacs,* ]) => do
+    for tac in tacs.getElems do
+      staticAutoTacticsExt.add (n.getNat, tac)
+  | `(command| #add_auto_tactics [ $tacs,* ]) => do
+    for tac in tacs.getElems do
+      staticAutoTacticsExt.add (0, tac)
+
+def getStaticAutoTactics (maxLevel : Nat) : MetaM (Array (Nat × TSyntax ``tacticSeq)) := do
+  return (staticAutoTacticsExt.getState (← getEnv)).filter (fun (level, _) => level ≤ maxLevel)
+
+initialize dynamicAutoTacticsExt :
+    SimpleScopedEnvExtension (Nat × Name) (Array (Nat × Name)) ←
+  registerSimpleScopedEnvExtension {
+    addEntry := fun m n =>
+        m.push n
+    initial := #[] -- empty by default
+  }
+
+syntax (name := autoTacticGen) "auto_tactic_gen" num : attr
+
+initialize registerBuiltinAttribute {
+  name := `auto_tactic_gen
+  descr := "Register goal dependent dynamic auto tactics."
+  add := fun decl stx kind => MetaM.run' do
+    let declTy := (← getConstInfo decl).type
+    let expectedType := Lean.Expr.forallE Lean.Name.anonymous (Lean.Expr.const `Lean.MVarId []) (Lean.Expr.forallE Lean.Name.anonymous (Lean.Expr.app (Lean.Expr.const `Array [Lean.Level.zero]) (Lean.Expr.const `Lean.Name [])) (Lean.Expr.app (Lean.Expr.const `Lean.Meta.MetaM []) (Lean.Expr.app (Lean.Expr.const `Lean.TSyntax []) (Lean.Expr.app (Lean.Expr.app (Lean.Expr.app (Lean.Expr.const `List.cons [Lean.Level.zero]) (Lean.Expr.const `Lean.SyntaxNodeKind [])) (Lean.Expr.app (Lean.Expr.const `Lean.Name.mkStr1 []) (Lean.Expr.lit (Lean.Literal.strVal "tacticSeq")))) (Lean.Expr.app (Lean.Expr.const `List.nil [Lean.Level.zero]) (Lean.Expr.const `Lean.SyntaxNodeKind []))))) (Lean.BinderInfo.default)) (Lean.BinderInfo.default)
+
+    unless (← withNewMCtxDepth <| isDefEqGuarded declTy expectedType) do
+      throwError s!"auto_tactic_gen attribute can only be applied to functions of type MVarId → Array Name → MetaM (TSyntax `tacticSeq), type of {decl} is {declTy}"
+    let level := stx.toNat
+    dynamicAutoTacticsExt.add (level, decl)
+}
+
+def getDynamicAutoTactics (goal : MVarId) (localNames: Array Name)(maxLevel : Nat) : MetaM (Array (Nat × TSyntax ``tacticSeq)) := do
+  let dynTacs := (dynamicAutoTacticsExt.getState (← getEnv)).filter (fun (level, _) => level ≤ maxLevel)
+  dynTacs.mapM fun (level, fn) => do
+    let tac ← unsafe evalConst (MVarId → Array Name → MetaM (TSyntax ``tacticSeq)) fn
+    let tacStx ← tac goal localNames
+    return (level, tacStx)
+
 
 end LeanAide

--- a/LeanAideCore/LeanAideCore/ConfigExts.lean
+++ b/LeanAideCore/LeanAideCore/ConfigExts.lean
@@ -115,17 +115,33 @@ initialize dynamicAutoTacticsExt :
     initial := #[] -- empty by default
   }
 
-syntax (name := autoTacticGen) "auto_tactic_gen" num : attr
-
 initialize registerBuiltinAttribute {
   name := `auto_tactic_gen
   descr := "Register goal dependent dynamic auto tactics."
   add := fun decl stx kind => MetaM.run' do
     let declTy := (← getConstInfo decl).type
-    let expectedType := Lean.Expr.forallE Lean.Name.anonymous (Lean.Expr.const `Lean.MVarId []) (Lean.Expr.forallE Lean.Name.anonymous (Lean.Expr.app (Lean.Expr.const `Array [Lean.Level.zero]) (Lean.Expr.const `Lean.Name [])) (Lean.Expr.app (Lean.Expr.const `Lean.Meta.MetaM []) (Lean.Expr.app (Lean.Expr.const `Lean.TSyntax []) (Lean.Expr.app (Lean.Expr.app (Lean.Expr.app (Lean.Expr.const `List.cons [Lean.Level.zero]) (Lean.Expr.const `Lean.SyntaxNodeKind [])) (Lean.Expr.app (Lean.Expr.const `Lean.Name.mkStr1 []) (Lean.Expr.lit (Lean.Literal.strVal "tacticSeq")))) (Lean.Expr.app (Lean.Expr.const `List.nil [Lean.Level.zero]) (Lean.Expr.const `Lean.SyntaxNodeKind []))))) (Lean.BinderInfo.default)) (Lean.BinderInfo.default)
+    let expectedType := Lean.Expr.forallE Lean.Name.anonymous (Lean.Expr.const `Lean.MVarId []) (Lean.Expr.forallE
+    Lean.Name.anonymous
+    (Lean.Expr.app (Lean.Expr.const `Array [Lean.Level.zero]) (Lean.Expr.const `Lean.Name []))
+    (Lean.Expr.app
+      (Lean.Expr.const `Lean.Meta.MetaM [])
+      (Lean.Expr.app
+        (Lean.Expr.const `Lean.TSyntax [])
+        (Lean.Expr.app
+          (Lean.Expr.app
+            (Lean.Expr.app (Lean.Expr.const `List.cons [Lean.Level.zero]) (Lean.Expr.const `Lean.SyntaxNodeKind []))
+            (Lean.Expr.app
+              (Lean.Expr.app
+                (Lean.Expr.app
+                  (Lean.Expr.app (Lean.Expr.const `Lean.Name.mkStr4 []) (Lean.Expr.lit (Lean.Literal.strVal "Lean")))
+                  (Lean.Expr.lit (Lean.Literal.strVal "Parser")))
+                (Lean.Expr.lit (Lean.Literal.strVal "Tactic")))
+              (Lean.Expr.lit (Lean.Literal.strVal "tacticSeq"))))
+          (Lean.Expr.app (Lean.Expr.const `List.nil [Lean.Level.zero]) (Lean.Expr.const `Lean.SyntaxNodeKind [])))))
+    (Lean.BinderInfo.default)) (Lean.BinderInfo.default)
 
     unless (← withNewMCtxDepth <| isDefEqGuarded declTy expectedType) do
-      throwError s!"auto_tactic_gen attribute can only be applied to functions of type MVarId → Array Name → MetaM (TSyntax `tacticSeq), type of {decl} is {declTy}"
+      throwError s!"auto_tactic_gen attribute can only be applied to functions of type {expectedType}, type of {decl} is {declTy}"
     let level := stx.toNat
     dynamicAutoTacticsExt.add (level, decl)
 }

--- a/LeanAideCore/LeanAideCore/RunTactics.lean
+++ b/LeanAideCore/LeanAideCore/RunTactics.lean
@@ -143,6 +143,10 @@ def simpWithSuggestions (goal: MVarId) (localNames : Array Name) (maxSuggestions
       `(simpLemma| $id:ident)
   `(tacticSeq| simp? [$params,*])
 
+def automationTactics (goal : MVarId) (localNames: Array Name)(maxLevel : Nat) : MetaM (List (TSyntax ``tacticSeq)) := do
+  let staticTacs ← getStaticAutoTactics maxLevel
+  let dynamicTacs ← getDynamicAutoTactics goal localNames maxLevel
+  return ((staticTacs ++ dynamicTacs).qsort (fun (level1, _) (level2, _) => level1 < level2)).toList.map (fun (_, tac) => tac)
 
 open Parser.Tactic
 def runForSingleGoal (mvarId : MVarId) (tacticCode : TSyntax ``tacticSeq) : TermElabM <| Option MVarId :=
@@ -366,12 +370,8 @@ def runTacticsAndFindTryThis? (goal : MVarId) (tacticSeqs : List (TSyntax ``tact
 
 
 def getQuickTactics? (goal: MVarId) (envHash? : Option UInt64) : TermElabM <| Option (TSyntax ``tacticSeq) := do
-  -- TODO-TacticOrderQuick: `try simp?; exact?` can be a slow failing
-  -- suggestion query.  Split cheap deterministic automation from expensive
-  -- suggestion tactics, and order this list using trace data on which tactic
-  -- succeeds fastest.
-  let tactics? ←
-    runTacticsAndFindTryThis? goal [← `(tacticSeq| simp?), ← `(tacticSeq| try simp?; exact?), ← `(tacticSeq| grind?)] envHash? (strict := true)
+  let autoTacs ← automationTactics goal #[] 1
+  let tactics? ← runTacticsAndFindTryThis? goal autoTacs envHash?
   match tactics? with
   | none => return none
   | some tacs =>

--- a/LeanAideCore/LeanAideCore/RunTactics.lean
+++ b/LeanAideCore/LeanAideCore/RunTactics.lean
@@ -513,17 +513,13 @@ partial def extractIntros (goal: MVarId) (maxDepth : Nat) (accum: List Name := [
 
 syntax (name := applyAnyTac) "apply_any?" : tactic
 
-@[tactic applyAnyTac] def applyAnyTacWrapper: Tactic := fun stx => do
+@[tactic applyAnyTac] def applyAnyTacImpl: Tactic := fun stx => do
   let goal ← getMainGoal
   goal.withContext do
 
     let lctx ← getLCtx
-    let visibleDecls := lctx.decls.toList.filterMap id |>.filter
-      (fun d => !d.isImplementationDetail)
 
-    let mut foundTac? : Option (TSyntax `tactic) := none
-
-    for decl in visibleDecls do
+    for decl in lctx do
       let isAccessible := !decl.userName.hasMacroScopes && !decl.userName.isInternal
 
       let tac ← if isAccessible then
@@ -535,26 +531,21 @@ syntax (name := applyAnyTac) "apply_any?" : tactic
 
       let state ← saveState
 
-      let success ← try
-        evalTactic tac
-        pure true
-      catch _ =>
-        pure false
-
-      state.restore
-      if success then
-        foundTac? := some tac
-
-        break
-      else
+      try
+        let (mvars, _) ← Elab.runTactic goal tac
         state.restore
+        if mvars.isEmpty then
+          TryThis.addSuggestion stx tac
+          return
+        else
+          continue
+      catch _ =>
+          state.restore
+          continue
+    traceAide `leanaide.interpreter.debug s!"apply_any? tactic did not find any applicable hypothesis."
+    throwError "apply_any? could not close the goal using hypotheses"
 
-    match foundTac? with
-    | some tac =>
-      TryThis.addSuggestion stx tac
-    | none =>
-      traceAide `leanaide.interpreter.debug s!"apply_any? tactic did not find any applicable hypothesis."
-      throwError "apply_any? failed: no local hypotheses could close the goal."
+
 
 
 -- open Lean Tactic Elab

--- a/LeanAideCore/LeanAideCore/RunTactics.lean
+++ b/LeanAideCore/LeanAideCore/RunTactics.lean
@@ -510,6 +510,53 @@ partial def extractIntros (goal: MVarId) (maxDepth : Nat) (accum: List Name := [
   | _, _ => do
     return (goal, accum)
 
+
+syntax (name := applyAnyTac) "apply_any?" : tactic
+
+@[tactic applyAnyTac] def applyAnyTacWrapper: Tactic := fun stx => do
+  let goal ← getMainGoal
+  goal.withContext do
+
+    let lctx ← getLCtx
+    let visibleDecls := lctx.decls.toList.filterMap id |>.filter
+      (fun d => !d.isImplementationDetail)
+
+    let mut foundTac? : Option (TSyntax `tactic) := none
+
+    for decl in visibleDecls do
+      let isAccessible := !decl.userName.hasMacroScopes && !decl.userName.isInternal
+
+      let tac ← if isAccessible then
+        let id := mkIdent decl.userName
+        `(tactic| apply $id)
+      else
+        let typeStx ← delabDetailed decl.type
+        `(tactic| apply ‹$typeStx›)
+
+      let state ← saveState
+
+      let success ← try
+        evalTactic tac
+        pure true
+      catch _ =>
+        pure false
+
+      state.restore
+      if success then
+        foundTac? := some tac
+
+        break
+      else
+        state.restore
+
+    match foundTac? with
+    | some tac =>
+      TryThis.addSuggestion stx tac
+    | none =>
+      traceAide `leanaide.interpreter.debug s!"apply_any? tactic did not find any applicable hypothesis."
+      throwError "apply_any? failed: no local hypotheses could close the goal."
+
+
 -- open Lean Tactic Elab
 -- def getPremiseNames (goalType: Expr)
 --     (selector: Option Selector := none)

--- a/LeanAideCore/LeanAideCore/RunTactics.lean
+++ b/LeanAideCore/LeanAideCore/RunTactics.lean
@@ -2,6 +2,7 @@ import Lean
 import LeanAideCore.Aides
 import LeanAideCore.SimpleFrontend
 import LeanAideCore.DefData
+import LeanAideCore.ConfigExts
 import Lean.LibrarySuggestions
 
 open Lean Meta Elab Term PrettyPrinter Nat Tactic
@@ -546,7 +547,12 @@ syntax (name := applyAnyTac) "apply_any?" : tactic
     throwError "apply_any? could not close the goal using hypotheses"
 
 
+#add_auto_tactics (level:= 0) [apply_any?]
+#add_auto_tactics (level:= 1) [simp?, grind?]
+#add_auto_tactics (level:= 2) [grind? +locals, try simp; exact?]
 
+
+@[auto_tactic_gen 2] def simpSuggestions: MVarId → Array Name → MetaM (TSyntax ``tacticSeq) := fun goal localNames => simpWithSuggestions goal localNames
 
 -- open Lean Tactic Elab
 -- def getPremiseNames (goalType: Expr)

--- a/LeanAideCore/LeanAideCore/TranslateM.lean
+++ b/LeanAideCore/LeanAideCore/TranslateM.lean
@@ -173,6 +173,7 @@ structure Translate.State where
   labelledTheorems : Array LabelledTheorem := #[]
   recentTranslations: Array ChatPair := #[] -- (input, output)
   numRecentTranslationsToUse : Nat := 0
+  automationLevel : Nat := 3
 deriving Inhabited
 
 /-- Monad with environment for translation -/
@@ -601,6 +602,16 @@ def withDeferredTheorems (x?: TranslateM (Option (TSyntax ``commandSeq))) : Tran
       let fullCmds := cmds ++ resCmds.push (← `(command| end))
       `(commandSeq| $fullCmds*)
 
+def getAutomationLevel : TranslateM Nat := return (← get).automationLevel
+
+def setAutomationLevel (n: Nat) : TranslateM Unit := do
+  modify fun s => {s with automationLevel := n}
+
+def withAutomationLevel (n: Nat) (x: TranslateM α) : TranslateM α := do
+  let oldLevel ← getAutomationLevel
+  setAutomationLevel n
+  try x finally setAutomationLevel oldLevel
+
 end Translate
 
 namespace TranslateM
@@ -614,15 +625,19 @@ def runWithEmbeddings (em : EmbedMap)
   x.run' {} |>.run'.run'
 
 
-def runToCore (x: TranslateM α) (em?: Option EmbedMap := none) (outputFile?: Option System.FilePath := none) : CoreM α := do
+def runToCore (x: TranslateM α) (em?: Option EmbedMap := none) (outputFile?: Option System.FilePath := none) (automationLevel? : Option Nat := some 3) : CoreM α := do
   match em? with
   | some em => runWithEmbeddings em x
   | none =>
-    match outputFile? with
-    | some file => do
+    match outputFile?, automationLevel? with
+    | some file, some level => do
+      IO.FS.writeFile file topCode
+      x.run' {outputFile := some file, automationLevel := level} |>.run'.run'
+    | some file, none =>
       IO.FS.writeFile file topCode
       x.run' {outputFile := some file} |>.run'.run'
-    | none => x.run' {} |>.run'.run'
+    | none, some level => x.run' {automationLevel := level} |>.run'.run'
+    | none, none => x.run' {} |>.run'.run'
 
 section Async
 open Std.Internal.IO.Async Async

--- a/LeanAideTest/RunTactics.lean
+++ b/LeanAideTest/RunTactics.lean
@@ -180,9 +180,11 @@ trace: [leanaide.frontend.debug] Try this:
 #guard_msgs in
 #findTryThis? ∀(n : Nat), n + 1 ≤ 3 using try_this (intro n; apply Nat.le_of_succ_le_succ) then (simp?; try(simp?); sorry)
 
+/-
 example : ∀ (n : ℕ), n + (1 : ℕ) ≤ (3 : ℕ) := by
   try_this(intro n; apply Nat.le_of_succ_le_succ)then(simp?; sorry)
 
+-/
 
 /--
 info: Try this:
@@ -195,7 +197,7 @@ Note: This linter can be disabled with `set_option linter.unusedVariables false`
 #guard_msgs in
 example (P Q : Prop) (hp : P) (hq : Q) : Q := by
   apply_any?
-  exact hq
+  apply hq
 
 /--
 info: Try this:
@@ -217,3 +219,8 @@ theorem hidden_hypotheses_example (P Q : Prop) (h : P ∧ Q) : P := by
   -- Instead, we can use the French quote syntax we discussed earlier
   -- to extract the inaccessible hypothesis by its type:
   exact ‹P›
+
+/-- error: apply_any? could not close the goal using hypotheses -/
+#guard_msgs in
+example (P Q : Prop) (h : P ∧ Q) : P := by
+  apply_any?

--- a/LeanAideTest/RunTactics.lean
+++ b/LeanAideTest/RunTactics.lean
@@ -182,3 +182,38 @@ trace: [leanaide.frontend.debug] Try this:
 
 example : ∀ (n : ℕ), n + (1 : ℕ) ≤ (3 : ℕ) := by
   try_this(intro n; apply Nat.le_of_succ_le_succ)then(simp?; sorry)
+
+
+/--
+info: Try this:
+  [apply] apply hq
+---
+warning: unused variable `hp`
+
+Note: This linter can be disabled with `set_option linter.unusedVariables false`
+-/
+#guard_msgs in
+example (P Q : Prop) (hp : P) (hq : Q) : Q := by
+  apply_any?
+  exact hq
+
+/--
+info: Try this:
+  [apply] apply ‹P›
+-/
+#guard_msgs in
+theorem hidden_hypotheses_example (P Q : Prop) (h : P ∧ Q) : P := by
+  -- We use `cases` to split the conjunction (AND) into its two parts.
+  -- However, we didn't tell Lean what to name the two new hypotheses!
+  cases h
+  apply_any?
+  -- At this exact line, if you look at the Lean infoview,
+  -- your proof state looks like this:
+  -- P Q : Prop
+  -- ✝¹ : P
+  -- ✝ : Q
+  -- ⊢ P
+  -- Because they have daggers, we cannot type `exact ✝¹`.
+  -- Instead, we can use the French quote syntax we discussed earlier
+  -- to extract the inaccessible hypothesis by its type:
+  exact ‹P›

--- a/codegen.lean
+++ b/codegen.lean
@@ -12,7 +12,7 @@ set_option maxRecDepth 1000
 set_option compiler.extract_closed false
 
 def usage : String :=
-  "Usage: lake env lean --run codegen.lean <structured-json-file>"
+  "Usage: lake env lean --run codegen.lean <structured-json-file> <--automation-level= n>"
 
 def stripJsonSuffix (name : String) : String :=
   if name.endsWith ".json" then
@@ -113,7 +113,7 @@ def formatElaborationResult (result : Json) : String :=
     formatSorries "Sorries after purge" "Sorries after purge: none" sorriesAfterPurge
   ]
 
-def runCodegen (inputPath : System.FilePath) : IO UInt32 := do
+def runCodegen (inputPath : System.FilePath) (level? : Option Nat) : IO UInt32 := do
   initSearchPath (← findSysroot)
   let raw ← IO.FS.readFile inputPath
   let js ←
@@ -135,7 +135,7 @@ def runCodegen (inputPath : System.FilePath) : IO UInt32 := do
       maxHeartbeats := 0
       maxRecDepth := 1000000 }
   let translator : Translator := {}
-  let core := leanFromStructuredJsonTask (taskJson js) translator |>.runToCore (outputFile? := some (liveOutputPathFor inputPath))
+  let core := leanFromStructuredJsonTask (taskJson js) translator |>.runToCore (outputFile? := some (liveOutputPathFor inputPath)) (automationLevel? := level?)
   let result ← core.run' ctx {env := env} |>.runToIO'
   match result.getObjValAs? String "result" with
   | Except.ok "success" =>
@@ -192,9 +192,25 @@ def runCodegen (inputPath : System.FilePath) : IO UInt32 := do
       IO.eprintln result.pretty
       return 1
 
-def main (args : List String) : IO UInt32 := do
+def autLevelFlagPrefix : String := "--automation-level="
+
+def parseArgs (args : List String) : Except String (System.FilePath × Option Nat) :=
   match args with
-  | [input] => runCodegen input
-  | _ => do
+  | [input, levelFlag] =>
+      if levelFlag.startsWith autLevelFlagPrefix then
+        let levelStr := levelFlag.drop autLevelFlagPrefix.length
+        match levelStr.toNat? with
+        | some n => Except.ok (System.mkFilePath [input], some n)
+        | none => Except.error s!"Invalid automation level: {levelStr}"
+      else
+        Except.error s!"Unknown argument: {levelFlag}"
+  | [input] => Except.ok (System.mkFilePath [input], none)
+  | _ => Except.error usage
+
+def main (args : List String) : IO UInt32 := do
+  match parseArgs args with
+  | Except.ok (inputPath, level?) => runCodegen inputPath level?
+  | Except.error err => do
+      IO.eprintln err
       IO.eprintln usage
       return 1

--- a/codegen.lean
+++ b/codegen.lean
@@ -158,7 +158,7 @@ def runCodegen (inputPath : System.FilePath) (level? : Option Nat) : IO UInt32 :
       -- "invalid 'import' command" because codegen is already running in an
       -- imported environment.  Validate the exact generated file in a fresh
       -- frontend, or strip imports from the in-process validation prefix.
-      let core := elaborateTask result translator |>.runToCore
+      let core := elaborateTask result translator |>.runToCore (automationLevel? := level?)
       let result' ← core.run' ctx {env := env} |>.runToIO'
       match result'.getObjValAs? String "result" with
       | Except.ok "success" =>


### PR DESCRIPTION
added the following changes to have refined automation tactics. pertains to #171.

1. `TranslateM` now has a `automationLevel` field with `3` as default value.
2. We have `getAutomationLevel`, `setAutomationLevel` and `withAutomationLevel` helper functions. `withAutomationLevel` could be used to override the automation level we get from the environment.
3. `runToCore` was changed to take in automation level as an input with default being `3` (the present situation). 
4. We can register static tactics (like `grind?`, `simp` etc.) using `#add_auto_tactics`. The syntax looks as follows:
```lean4
#add_auto_tactics (level:= 2) [try simp; exact?]
```
Here, level is the automation level. The higher the level, the more expensive the frontend run.
5. We can register dynamic tactics (like simpWithSuggestions) using the attribute `auto_tac_gen`. As of now the dynamic tactics are assumed to be of type `MVarId -> Array Name -> TSyntax tacticSeq`. This can be changed into something more general as need arises. This follows exactly the `codegen` attribute style. 

The syntax for registering using `auto_tac_gen` looks like this:

```lean4
@[auto_tactic_gen 2] def simpSuggestions: MVarId → Array Name → MetaM (TSyntax ``tacticSeq) := fun goal localNames => simpWithSuggestions goal localNames
```

Again, the `2` after `auto_tactic_gen` is the automation level. 

6. The automation level can be fixed as follows while running on command line:
```bash
lake exe codegen input.json --automation-level=n
```

7. These are the tactics registered as of now:

Level 0 : `apply_any?`
Level 1: `simp?`, `grind?`
Level 2 : `grind? +locals` , `try simp; exact?`, `simpWithSuggestions`
Level 3 : `llm?`, `hammer`
